### PR TITLE
Added peace treaties to faction/basic.js

### DIFF
--- a/src/api-schema/faction/basic.ts
+++ b/src/api-schema/faction/basic.ts
@@ -1,4 +1,4 @@
-import { EpochSeconds, Integer, String, Unknown } from "@/api-schema/common-types";
+import { EpochSeconds, Integer, String } from "@/api-schema/common-types";
 import { fromStructure, Schema, Selection, Structure, StructureEnum } from "@/api-schema/schema.types";
 import { lastActionStatusEnum, lastActionStructure } from "@/api-schema/shared/last-action";
 import { factionsStructure, rankedWarFactionStructure, rankedWarsStructure, rankedWarStructure, warStructure } from "@/api-schema/shared/ranked-wars";

--- a/src/api-schema/faction/basic.ts
+++ b/src/api-schema/faction/basic.ts
@@ -47,6 +47,13 @@ const membersStructure: Structure = {
         "<user id>": fromStructure(memberStructure),
     },
 };
+const peaceStructure: Structure = {
+    id: "peace",
+    name: "Peace Treaties",
+    schema: {
+        "<faction id>": { type: EpochSeconds },
+    },
+};
 const rankEnum: StructureEnum<string> = {
     id: "rank",
     name: "Rank",
@@ -87,8 +94,9 @@ const factionStructure: Structure = {
             array: true,
             extra: "Empty object when there is no raid.",
         }),
-        // FIXME - Map field correctly.
-        peace: { type: Unknown },
+        peace: fromStructure(peaceStructure, {
+            extra: "Empty object when there are no peace treaties.",
+        }),
         rank: fromStructure(rankStructure),
         members: fromStructure(membersStructure),
     },
@@ -111,6 +119,7 @@ const structures = [
     warStructure,
     territoryWarStructure,
     raidStructure,
+    peaceStructure,
 ];
 
 const schema: Schema = {


### PR DESCRIPTION
The "peace" key in the faction/basic call returns a dictionary with the keys being the faction the peace treaty is with. The value is the Unix timestamp for when the peace treaty expires.

<details>
<summary>Example Faction: 47760</summary>

> GET https<nolink>://api.torn.com/faction/47760?selections=&key={{ KEY }}
```
{
    "ID": 47760,
    "name": "Ninja Medics",
    ...
    "peace": {
        "25857": 1681722571,
        "46022": 1697998376,
    },
}
```
</details>

<details>
<summary>Normal Faction: 3241</summary>

> GET https<nolink>://api.torn.com/faction/3241?selections=&key={{ KEY }}
```
{
    "ID": 3241,
    "name": "JFK",
    ...
    "peace": {},
}
```
</details