### PR TITLE
Correct faction/booster root object name.

### DIFF
--- a/src/api-schema/faction/boosters.ts
+++ b/src/api-schema/faction/boosters.ts
@@ -4,7 +4,7 @@ import { armoryItemStructure } from "@/api-schema/shared/armory";
 const structures = [armoryItemStructure];
 
 const schema: Schema = {
-    drugs: fromStructure(armoryItemStructure, { array: true }),
+    boosters: fromStructure(armoryItemStructure, { array: true }),
 };
 
 const BoostersSelection: Selection = {


### PR DESCRIPTION
Field is named boosters not drugs. 

![image](https://github.com/Torn-Playground/tornapi-documentation/assets/59464917/6cba95f8-3b31-4c88-b2e2-17e6841b6b36)
