### PR TITLE
Fixed field name from bazaar to display in display.ts

### DIFF
--- a/src/api-schema/user/display.ts
+++ b/src/api-schema/user/display.ts
@@ -17,7 +17,7 @@ const displayItemStructure: Structure = {
 const structures = [displayItemStructure];
 
 const schema: Schema = {
-    bazaar: fromStructure(displayItemStructure, { array: true }),
+    display: fromStructure(displayItemStructure, { array: true }),
 };
 
 const DisplaySelection: Selection = {


### PR DESCRIPTION
The returned field name by the API is display

```json

{
        "display": [
                {
                        "ID": 744,
                        "name": "Book : Brawn Over Brains",
                        "type": "Book",
                        "quantity": 1,
                        "circulation": 11302,
                        "market_price": 0,
                }
           ]
}

```