### PR TITLE
Match custom selector styling + fix accent styles

### DIFF
--- a/src/components/try-it/url-selector/SelectionSelector.tsx
+++ b/src/components/try-it/url-selector/SelectionSelector.tsx
@@ -94,7 +94,7 @@ export default function SelectionSelector({ onSelectionsChange, section, onCusto
                 <span key={`custom-${index}`} className="badge badge-lg badge-accent cursor-pointer">
                     <input
                         type="text"
-                        className="input input-ghost input-xs w-24"
+                        className="input input-ghost input-xs w-24 py-0 bg-transparent focus:outline-none !text-accent-content text-base"
                         value={selection}
                         onChange={(event) => updateCustomSelection(event, index)}
                     />


### PR DESCRIPTION
### Before:
![Light mode](https://i.imgur.com/LJiNYJL.gif)
![Dark mode](https://i.imgur.com/QAiwcBJ.gif)

### After:
![Light mode](https://i.imgur.com/pFwj9zL.gif)
![Dark mode](https://i.imgur.com/kr6V8gm.gif)

## Changes:
- Removed vertical padding (you may want to change the horizontal padding too as it's padded by the span *and* the input on the left, but this was more opinionated so I left it as-is)
- Remove input background and outline whilst active (OS may still leave the blue outline, but I'd leave this for accesibility reasons IMO)
- Set text color to the accent-content (generated by Daisy to be accessible when an element as an accent-colored BG)
- Match text size in both custom and standard elements